### PR TITLE
Feature/1 create subdomain for static site deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Booster.configure('development', (config: BoosterConfig): void => {
       rootPath: './frontend/dist', // Defaults to ./public
       indexFile: 'main.html', // File to render when users access the CLoudFormation URL. Defaults to index.html
       errorFile: 'error.html', // File to render when there's an error. Defaults to 404.html
+      domainName: 'www.examplepage.test', // This will add the domain including a SSL Certificate with DNS validation to the CloudFront distribution and add an alias record in the Route53 registry. Basedomain needs to exist in Route53. Defaults to undefined
     }
   }])
 })

--- a/package.json
+++ b/package.json
@@ -23,7 +23,10 @@
     "url": "git+https://github.com/boostercloud/rocket-static-sites-aws-infrastructure.git"
   },
   "dependencies": {
+    "@aws-cdk/aws-certificatemanager": "1.91.0",
     "@aws-cdk/aws-cloudfront": "1.91.0",
+    "@aws-cdk/aws-route53": "1.91.0",
+    "@aws-cdk/aws-route53-targets": "1.91.0",
     "@aws-cdk/aws-s3": "1.91.0",
     "@aws-cdk/aws-s3-deployment": "1.91.0",
     "@aws-cdk/core": "1.91.0",
@@ -44,16 +47,15 @@
   },
   "devDependencies": {
     "@boostercloud/framework-provider-aws-infrastructure": "0.20.2",
+    "@semantic-release/git": "^9.0.0",
+    "@semantic-release/npm": "^7.0.10",
     "@types/faker": "5.1.5",
     "@types/mocha": "^5.2.7",
     "@types/node": "14.14.20",
     "@types/sinon": "^9.0.10",
-    "metadata-booster": "0.3.1",
     "@types/sinon-chai": "^3.2.5",
     "@typescript-eslint/eslint-plugin": "^2.18.0",
     "@typescript-eslint/parser": "^2.18.0",
-    "@semantic-release/git": "^9.0.0",
-    "@semantic-release/npm": "^7.0.10",
     "aws-cdk": "1.91.0",
     "chai": "4.2.0",
     "chai-as-promised": "7.1.1",
@@ -62,15 +64,16 @@
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-prettier": "^3.1.2",
     "faker": "5.1.0",
+    "metadata-booster": "0.3.1",
     "mocha": "^8.3.0",
     "nyc": "^15.1.0",
     "prettier": "^1.19.1",
     "sinon": "9.2.3",
     "sinon-chai": "3.5.0",
-    "velocityjs": "^2.0.0",
     "ts-node": "^9.1.1",
+    "tslib": "2.1.0",
     "typescript": "^4.2.2",
-    "tslib": "2.1.0"
+    "velocityjs": "^2.0.0"
   },
   "release": {
     "branches": [

--- a/src/static-website-stack.ts
+++ b/src/static-website-stack.ts
@@ -40,19 +40,6 @@ export class StaticWebsiteStack {
 
       staticSiteBucket.grantRead(staticWebsiteOIA)
 
-      const errorConfigurations: CfnDistribution.CustomErrorResponseProperty[] = [
-        {
-          errorCode: 403,
-          responsePagePath: "/",
-          responseCode: 200,
-        },
-        {
-          errorCode: 404,
-          responsePagePath: "/index.html",
-          responseCode: 200,
-        },
-      ];
-
       // We are using a Zone that already exists so we can use a lookup on the Zone name.
       const zone = domainName ? route53.HostedZone.fromLookup(stack, 'baseZone', { domainName: domainName }) : undefined
 

--- a/test/static-website-stack.test.ts
+++ b/test/static-website-stack.test.ts
@@ -94,4 +94,46 @@ describe('Static website creation', () => {
       expect(cfnOutput).not.to.be.undefined
     })
   })
+
+  context('when connect Domain to distribution', () => {
+    it('builds the website stack of a full-stack app correctly if public directory exists', () => {
+      const fakeExistsAsync = fake.resolves(true)
+      replace(fs, 'existsSync', fakeExistsAsync)
+
+      const appStack = new Stack(new App(), config.resourceNames.applicationStack, {
+        env: { account: '111111111111', region: 'us-east-1' },
+      } as StackProps)
+
+      stub(Source, 'asset').returns({
+        bind: () =>
+          ({
+            bucket: new Bucket(appStack, 'fakeBucket', {} as BucketProps),
+            zipObjectKey: 'staticSiteDeployment.zip',
+          } as SourceConfig),
+      })
+
+      StaticWebsiteStack.mountStack(
+        {
+          bucketName: 'test-bucket-name',
+          rootPath: './frontend/dist',
+          indexFile: 'main.html',
+          errorFile: 'error.html',
+          domainName: 'www.exampledomain.test',
+        },
+        appStack
+      )
+
+      expect(fakeExistsAsync).to.have.been.calledWith('./frontend/dist')
+
+      const staticSiteBucket = appStack.node.tryFindChild(staticWebsiteBucket) as Bucket
+      const cloudFrontDistribution = appStack.node.tryFindChild(staticWebsiteDistribution) as CloudFrontWebDistribution
+      const bucketDeployment = appStack.node.tryFindChild(staticWebsiteDeployment) as BucketDeployment
+      const cfnOutput = appStack.node.tryFindChild(cfnOutputId) as CfnOutput
+
+      expect(staticSiteBucket).not.to.be.undefined
+      expect(bucketDeployment).not.to.be.undefined
+      expect(cloudFrontDistribution).not.to.be.undefined
+      expect(cfnOutput).not.to.be.undefined
+    })
+  })
 })


### PR DESCRIPTION
## Description
Allow to add a domain for the static site deployment including creating a valid SSL certificate and connecting the cloud front distribution with Rout53.
Fix Issue #1

## Changes
* add configuration options
* 

## Checks
- [x] Project Builds
- [ ] Project passes tests and checks
- [x] Updated documentation accordingly
 
## Additional information
